### PR TITLE
fix: arrays not becoming reactive

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exalt/core",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/runtime/reactive.js
+++ b/packages/core/src/runtime/reactive.js
@@ -48,10 +48,7 @@ export function createReactiveObject(value, callback) {
 
 /* create a reactive array */
 export function createReactiveArray(value, callback) {
-    const proxy = new Proxy([], mutate(callback, true));
-    /* we merge the value with the proxy to ensure than nested values become reactive */
-    proxy.push(...value);
-    return proxy;
+    return new Proxy(value, mutate(callback, true));
 }
 
 /* handle the mutation of an object or array wrapped in a proxy */


### PR DESCRIPTION
Fixed arrays not becoming reactive by making the array be directly wrapped in a proxy and returned.
fixes #3 